### PR TITLE
Fix repo URL in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     author_email="ikreymer@gmail.com",
     license="Apache 2.0",
     packages=find_packages(),
-    url="https://github.com/webrecorder/cdxj_indexer",
+    url="https://github.com/webrecorder/cdxj-indexer",
     description="CDXJ Indexer for WARC and ARC files",
     long_description=open("README.rst").read(),
     provides=["cdxj_indexer",],


### PR DESCRIPTION
In Pypi, I noticed that the link to the source repo ("homepage" in the Pypi UI) goes to https://github.com/webrecorder/cdxj_indexer when the source repo is located at https://github.com/webrecorder/cdxj-indexer (noting the `_` vs `-`).

This subtle change should fix the link represented in Pypi.