### PR TITLE
post request indexing improvements

### DIFF
--- a/cdxj_indexer/main.py
+++ b/cdxj_indexer/main.py
@@ -255,8 +255,8 @@ class CDXJIndexer(Indexer):
         else:
             urlkey = self.get_url_key(url)
 
-        if hasattr(record, "append_q"):
-            index["requestBody"] = record.append_q
+        if hasattr(record, "requestBody"):
+            index["requestBody"] = record.requestBody
         if hasattr(record, "method"):
             index["method"] = record.method
 
@@ -343,10 +343,10 @@ class CDXJIndexer(Indexer):
         method = req.http_headers.protocol
         if self.post_append and method.upper() in ("POST", "PUT"):
             url = req.rec_headers.get_header("WARC-Target-URI")
-            append_q = append_method_query(req, resp)
+            query, append_str = append_method_query(req, resp)
             resp.method = method.upper()
-            resp.append_q = append_q
-            resp.urlkey = self.get_url_key(url + append_q)
+            resp.requestBody = query
+            resp.urlkey = self.get_url_key(url + append_str)
             req.urlkey = resp.urlkey
 
 

--- a/cdxj_indexer/postquery.py
+++ b/cdxj_indexer/postquery.py
@@ -20,13 +20,13 @@ def append_method_query(req, resp):
     query = query_extract(content_type, len_, stream, url)
 
     if "?" not in url:
-        append_q = "?"
+        append_str = "?"
     else:
-        append_q = "&"
+        append_str = "&"
 
     method = req.http_headers.protocol
-    append_q += "__wb_method=" + method + "&" + query
-    return append_q
+    append_str += "__wb_method=" + method + "&" + query
+    return query, append_str
 
 
 # ============================================================================

--- a/cdxj_indexer/postquery.py
+++ b/cdxj_indexer/postquery.py
@@ -5,37 +5,39 @@ from io import BytesIO
 
 import base64
 import cgi
+import json
 
 
 # ============================================================================
-def append_post_query(req, resp):
+def append_method_query(req, resp):
     len_ = req.http_headers.get_header("Content-Length")
     content_type = req.http_headers.get_header("Content-Type")
     stream = req.buffered_stream
     stream.seek(0)
 
-    post_query = post_query_extract(content_type, len_, stream)
-
     url = req.rec_headers.get_header("WARC-Target-URI")
 
-    if "?" not in url:
-        url += "?"
-    else:
-        url += "&"
+    query = query_extract(content_type, len_, stream, url)
 
-    url += post_query
-    return url
+    if "?" not in url:
+        append_q = "?"
+    else:
+        append_q = "&"
+
+    method = req.http_headers.protocol
+    append_q += "__wb_method=" + method + "&" + query
+    return append_q
 
 
 # ============================================================================
-def post_query_extract(mime, length, stream):
+def query_extract(mime, length, stream, url):
     """
     Extract a url-encoded form POST/PUT from stream
     content length, return None
     Attempt to decode application/x-www-form-urlencoded or multipart/*,
     otherwise read whole block and b64encode
     """
-    post_query = b""
+    query = b""
 
     try:
         length = int(length)
@@ -50,23 +52,32 @@ def post_query_extract(mime, length, stream):
         if not buff:
             break
 
-        post_query += buff
+        query += buff
 
     if not mime:
         mime = ""
 
-    if mime.startswith("application/x-www-form-urlencoded"):
-        post_query = post_query.decode("utf-8")
-        post_query = unquote_plus(post_query)
+    def handle_binary(query):
+        query = base64.b64encode(query)
+        query = to_native_str(query)
+        query = '__wb_post_data=' + query
+        return query
+
+    if mime.startswith('application/x-www-form-urlencoded'):
+        try:
+            query = to_native_str(query.decode('utf-8'))
+            query = unquote_plus(query)
+        except UnicodeDecodeError:
+            query = handle_binary(query)
 
     elif mime.startswith("multipart/"):
         env = {
             "REQUEST_METHOD": "POST",
             "CONTENT_TYPE": mime,
-            "CONTENT_LENGTH": len(post_query),
+            "CONTENT_LENGTH": len(query),
         }
 
-        args = dict(fp=BytesIO(post_query), environ=env, keep_blank_values=True)
+        args = dict(fp=BytesIO(query), environ=env, keep_blank_values=True)
 
         args["encoding"] = "utf-8"
 
@@ -76,11 +87,36 @@ def post_query_extract(mime, length, stream):
         for item in data.list:
             values.append((item.name, item.value))
 
-        post_query = urlencode(values, True)
+        query = urlencode(values, True)
+
+    elif mime.startswith('application/json'):
+        query = json_parse(query.decode("utf-8"), True)
+
+    elif mime.startswith('text/plain'):
+        query = json_parse(query.decode("utf-8"), False)
 
     else:
-        post_query = base64.b64encode(post_query)
-        post_query = to_native_str(post_query)
-        post_query = "__warc_post_data=" + post_query
+        query = handle_binary(query)
 
-    return post_query
+    return query
+
+def json_parse(string, warn_on_error=False):
+    data = {}
+
+    def _parser(dict_var):
+        for n, v in dict_var.items():
+            if isinstance(v, dict):
+                _parser(v)
+            else:
+                data[n] = v
+
+    try:
+        _parser(json.loads(string))
+    except Exception as e:
+        if warn_on_error:
+            print(e)
+
+    return urlencode(data)
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 
 
 class PyTest(TestCommand):

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -137,9 +137,9 @@ com,example)/ 20140401000000 http://example.com/ - - 3I42H3S6NNFQ2MSVX7XZKYAYSCX
     def test_warc_post_query_append(self):
         res = self.index_file("post-test.warc.gz", post_append=True)
         exp = """\
-org,httpbin)/post?__wb_method=post&foo=bar&test=abc 20140610000859 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M532K5WS4GY2H4OVZO6HRPOP47A7KDWU", "length": "720", "offset": "0", "filename": "post-test.warc.gz", "requestBody": "?__wb_method=POST&foo=bar&test=abc", "method": "POST"}
-org,httpbin)/post?__wb_method=post&a=1&b=[]&c=3 20140610001151 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2", "length": "723", "offset": "1196", "filename": "post-test.warc.gz", "requestBody": "?__wb_method=POST&A=1&B=[]&C=3", "method": "POST"}
-org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=bar", "mime": "application/json", "status": "200", "digest": "B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ", "length": "723", "offset": "2395", "filename": "post-test.warc.gz", "requestBody": "&__wb_method=POST&data=^", "method": "POST"}
+org,httpbin)/post?__wb_method=post&foo=bar&test=abc 20140610000859 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M532K5WS4GY2H4OVZO6HRPOP47A7KDWU", "length": "720", "offset": "0", "filename": "post-test.warc.gz", "requestBody": "foo=bar&test=abc", "method": "POST"}
+org,httpbin)/post?__wb_method=post&a=1&b=[]&c=3 20140610001151 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2", "length": "723", "offset": "1196", "filename": "post-test.warc.gz", "requestBody": "A=1&B=[]&C=3", "method": "POST"}
+org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=bar", "mime": "application/json", "status": "200", "digest": "B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ", "length": "723", "offset": "2395", "filename": "post-test.warc.gz", "requestBody": "data=^", "method": "POST"}
 """
         assert res == exp
 
@@ -154,9 +154,9 @@ org,httpbin)/post?foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=ba
     def test_warc_post_query_append_multi_and_json(self):
         res = self.index_file("post-test-more.warc", post_append=True)
         exp = """\
-org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "7AWVEIPQMCA4KTCNDXWSZ465FITB7LSK", "length": "688", "offset": "0", "filename": "post-test-more.warc", "requestBody": "?__wb_method=POST&test=some+data&another=more%5Edata", "method": "POST"}
-org,httpbin)/post?__wb_method=post&a=json-data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "BYOQWRSQFW3A5SNUBDSASHFLXGL4FNGB", "length": "655", "offset": "1227", "filename": "post-test-more.warc", "requestBody": "?__wb_method=POST&a=json-data", "method": "POST"}
-org,httpbin)/post?__wb_method=post&__wb_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 20200810055049 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "34LEADQD3MOBQ42FCO2WA5TUSEL5QOKP", "length": "628", "offset": "2338", "filename": "post-test-more.warc", "requestBody": "?__wb_method=POST&__wb_post_data=c29tZWNodW5rLWVuY29kZWRkYXRh", "method": "POST"}
+org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "7AWVEIPQMCA4KTCNDXWSZ465FITB7LSK", "length": "688", "offset": "0", "filename": "post-test-more.warc", "requestBody": "test=some+data&another=more%5Edata", "method": "POST"}
+org,httpbin)/post?__wb_method=post&a=json-data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "BYOQWRSQFW3A5SNUBDSASHFLXGL4FNGB", "length": "655", "offset": "1227", "filename": "post-test-more.warc", "requestBody": "a=json-data", "method": "POST"}
+org,httpbin)/post?__wb_method=post&__wb_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 20200810055049 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "34LEADQD3MOBQ42FCO2WA5TUSEL5QOKP", "length": "628", "offset": "2338", "filename": "post-test-more.warc", "requestBody": "__wb_post_data=c29tZWNodW5rLWVuY29kZWRkYXRh", "method": "POST"}
 """
         assert res == exp
 
@@ -173,8 +173,8 @@ org,httpbin)/post?__wb_method=post&__wb_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 2
 
         exp = """\
 !meta 0 {"format": "cdxj-gzip-1.0", "filename": "%s"}
-com,example)/ 20140102000000 {"offset": 0, "length": 746}
-org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 20200809195334 {"offset": 746, "length": 424}
+com,example)/ 20140102000000 {"offset": 0, "length": 742}
+org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 20200809195334 {"offset": 742, "length": 416}
 """
         assert res == exp % "comp.cdxj.gz"
 

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -137,9 +137,9 @@ com,example)/ 20140401000000 http://example.com/ - - 3I42H3S6NNFQ2MSVX7XZKYAYSCX
     def test_warc_post_query_append(self):
         res = self.index_file("post-test.warc.gz", post_append=True)
         exp = """\
-org,httpbin)/post?foo=bar&test=abc 20140610000859 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M532K5WS4GY2H4OVZO6HRPOP47A7KDWU", "length": "720", "offset": "0", "filename": "post-test.warc.gz"}
-org,httpbin)/post?a=1&b=[]&c=3 20140610001151 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2", "length": "723", "offset": "1196", "filename": "post-test.warc.gz"}
-org,httpbin)/post?data=^&foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=bar", "mime": "application/json", "status": "200", "digest": "B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ", "length": "723", "offset": "2395", "filename": "post-test.warc.gz"}
+org,httpbin)/post?__wb_method=post&foo=bar&test=abc 20140610000859 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M532K5WS4GY2H4OVZO6HRPOP47A7KDWU", "length": "720", "offset": "0", "filename": "post-test.warc.gz", "requestBody": "?__wb_method=POST&foo=bar&test=abc", "method": "POST"}
+org,httpbin)/post?__wb_method=post&a=1&b=[]&c=3 20140610001151 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2", "length": "723", "offset": "1196", "filename": "post-test.warc.gz", "requestBody": "?__wb_method=POST&A=1&B=[]&C=3", "method": "POST"}
+org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=bar", "mime": "application/json", "status": "200", "digest": "B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ", "length": "723", "offset": "2395", "filename": "post-test.warc.gz", "requestBody": "&__wb_method=POST&data=^", "method": "POST"}
 """
         assert res == exp
 
@@ -154,9 +154,9 @@ org,httpbin)/post?foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=ba
     def test_warc_post_query_append_multi_and_json(self):
         res = self.index_file("post-test-more.warc", post_append=True)
         exp = """\
-org,httpbin)/post?another=more^data&test=some+data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "7AWVEIPQMCA4KTCNDXWSZ465FITB7LSK", "length": "688", "offset": "0", "filename": "post-test-more.warc"}
-org,httpbin)/post?__warc_post_data=eyjzb21lijogeyjhijogimpzb24tzgf0ysj9fq== 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "BYOQWRSQFW3A5SNUBDSASHFLXGL4FNGB", "length": "655", "offset": "1227", "filename": "post-test-more.warc"}
-org,httpbin)/post?__warc_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 20200810055049 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "34LEADQD3MOBQ42FCO2WA5TUSEL5QOKP", "length": "628", "offset": "2338", "filename": "post-test-more.warc"}
+org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "7AWVEIPQMCA4KTCNDXWSZ465FITB7LSK", "length": "688", "offset": "0", "filename": "post-test-more.warc", "requestBody": "?__wb_method=POST&test=some+data&another=more%5Edata", "method": "POST"}
+org,httpbin)/post?__wb_method=post&a=json-data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "BYOQWRSQFW3A5SNUBDSASHFLXGL4FNGB", "length": "655", "offset": "1227", "filename": "post-test-more.warc", "requestBody": "?__wb_method=POST&a=json-data", "method": "POST"}
+org,httpbin)/post?__wb_method=post&__wb_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 20200810055049 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "34LEADQD3MOBQ42FCO2WA5TUSEL5QOKP", "length": "628", "offset": "2338", "filename": "post-test-more.warc", "requestBody": "?__wb_method=POST&__wb_post_data=c29tZWNodW5rLWVuY29kZWRkYXRh", "method": "POST"}
 """
         assert res == exp
 
@@ -173,8 +173,8 @@ org,httpbin)/post?__warc_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 20200810055049 {
 
         exp = """\
 !meta 0 {"format": "cdxj-gzip-1.0", "filename": "%s"}
-com,example)/ 20140102000000 {"offset": 0, "length": 696}
-org,httpbin)/post?another=more^data&test=some+data 20200809195334 {"offset": 696, "length": 364}
+com,example)/ 20140102000000 {"offset": 0, "length": 746}
+org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 20200809195334 {"offset": 746, "length": 424}
 """
         assert res == exp % "comp.cdxj.gz"
 


### PR DESCRIPTION
Improvements for POST indexing:
- store post (and other method) body in `requestBody` as query string
- index application/json, and try text/plain as json, to convert primitive values to query args, eg `{"a": "b", "c": "d"}` -> `a=b&c=d`
- store method in `method` field, add to urlkey as `__wb_method=...`
- implementation in sync with warcio.js