### PR TITLE
Support for record and compressed block digest + POST append compatibility with pywb (1.4.0)

### DIFF
--- a/cdxj_indexer/amf.py
+++ b/cdxj_indexer/amf.py
@@ -7,7 +7,6 @@ from six.moves.urllib.parse import urlencode
 
 
 class Amf:
-
     @staticmethod
     def get_representation(request_object, max_calls=500):
 
@@ -23,7 +22,9 @@ class Amf:
                 bodies.append(Amf.get_representation(i[1], max_calls))
             bodies = sorted(bodies)
 
-            return "<Envelope>{bodies}</Envelope>".format(bodies="[" + ",".join(bodies) + "]")
+            return "<Envelope>{bodies}</Envelope>".format(
+                bodies="[" + ",".join(bodies) + "]"
+            )
 
         elif isinstance(request_object, Request):
             # Remove cyclic reference
@@ -35,7 +36,9 @@ class Amf:
             # Remove random properties
             operation = request_object.operation
             body = Amf.get_representation(request_object.body, max_calls)
-            return "<RemotingMessage operation={operation}>{body}</RemotingMessage>".format(**locals())
+            return "<RemotingMessage operation={operation}>{body}</RemotingMessage>".format(
+                **locals()
+            )
 
         elif isinstance(request_object, dict):
             return json.dumps(request_object, sort_keys=True)
@@ -57,10 +60,12 @@ class Amf:
             properties = request_object.__dict__
             bodies = dict()
             for prop in properties:
-                bodies[prop] = Amf.get_representation(getattr(request_object, prop), max_calls)
+                bodies[prop] = Amf.get_representation(
+                    getattr(request_object, prop), max_calls
+                )
             bodies = Amf.get_representation(bodies, max_calls)
 
-            return '<{classname}>{bodies}</{classname}>'.format(**locals())
+            return "<{classname}>{bodies}</{classname}>".format(**locals())
 
         else:
             return repr(request_object)
@@ -73,8 +78,7 @@ def amf_parse(string):
 
     except Exception as e:
         import traceback
+
         traceback.print_exc()
         print(e)
         return None
-
-

--- a/cdxj_indexer/amf.py
+++ b/cdxj_indexer/amf.py
@@ -1,0 +1,80 @@
+import json
+import six
+from pyamf.remoting import Envelope, Request, decode
+from pyamf.flex.messaging import RemotingMessage
+from io import BytesIO
+from six.moves.urllib.parse import urlencode
+
+
+class Amf:
+
+    @staticmethod
+    def get_representation(request_object, max_calls=500):
+
+        max_calls = max_calls - 1
+
+        if max_calls < 0:
+            raise Exception("Amf.get_representation maximum number of calls reached")
+
+        if isinstance(request_object, Envelope):
+            # Remove order of Request
+            bodies = []
+            for i in request_object.bodies:
+                bodies.append(Amf.get_representation(i[1], max_calls))
+            bodies = sorted(bodies)
+
+            return "<Envelope>{bodies}</Envelope>".format(bodies="[" + ",".join(bodies) + "]")
+
+        elif isinstance(request_object, Request):
+            # Remove cyclic reference
+            target = request_object.target
+            body = Amf.get_representation(request_object.body, max_calls)
+            return "<Request target={target}>{body}</Request>".format(**locals())
+
+        elif isinstance(request_object, RemotingMessage):
+            # Remove random properties
+            operation = request_object.operation
+            body = Amf.get_representation(request_object.body, max_calls)
+            return "<RemotingMessage operation={operation}>{body}</RemotingMessage>".format(**locals())
+
+        elif isinstance(request_object, dict):
+            return json.dumps(request_object, sort_keys=True)
+
+        elif isinstance(request_object, list):
+            bodies = []
+            for i in request_object:
+                bodies.append(Amf.get_representation(i, max_calls))
+            return "[" + ",".join(bodies) + "]"
+
+        elif isinstance(request_object, six.string_types):
+            return request_object
+
+        elif request_object is None:
+            return ""
+
+        elif isinstance(request_object, object) and hasattr(request_object, "__dict__"):
+            classname = request_object.__class__.__name__
+            properties = request_object.__dict__
+            bodies = dict()
+            for prop in properties:
+                bodies[prop] = Amf.get_representation(getattr(request_object, prop), max_calls)
+            bodies = Amf.get_representation(bodies, max_calls)
+
+            return '<{classname}>{bodies}</{classname}>'.format(**locals())
+
+        else:
+            return repr(request_object)
+
+
+def amf_parse(string):
+    try:
+        res = decode(BytesIO(string))
+        return urlencode({"request": Amf.get_representation(res)})
+
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(e)
+        return None
+
+

--- a/cdxj_indexer/main.py
+++ b/cdxj_indexer/main.py
@@ -577,7 +577,9 @@ def main(args=None):
 
     parser.add_argument("-c", "--compress")
 
-    parser.add_argument("-l", "--lines", type=int, default=CDXJIndexer.DEFAULT_NUM_LINES)
+    parser.add_argument(
+        "-l", "--lines", type=int, default=CDXJIndexer.DEFAULT_NUM_LINES
+    )
 
     parser.add_argument("-d", "--digest-records", action="store_true")
 

--- a/cdxj_indexer/main.py
+++ b/cdxj_indexer/main.py
@@ -230,8 +230,6 @@ class CDXJIndexer(Indexer):
     def process_one(self, input_, output, filename):
         self.curr_filename = self.force_filename or self._resolve_rel_path(filename)
 
-        # input_ = DigestReader(input_)
-
         it = self._create_record_iter(input_)
 
         self._write_header(output, filename)
@@ -268,8 +266,6 @@ class CDXJIndexer(Indexer):
             self.writer.ensure_digest(record, block=False, payload=True)
             value = record.rec_headers.get(name)
 
-        # if value:
-        #    value = value.split(":")[-1]
         return value
 
     def _write_line(self, out, index, record, filename):

--- a/cdxj_indexer/postquery.py
+++ b/cdxj_indexer/postquery.py
@@ -3,29 +3,45 @@ from warcio.utils import to_native_str
 from urllib.parse import unquote_plus, urlencode
 from io import BytesIO
 
+from cdxj_indexer.amf import amf_parse
+
 import base64
 import cgi
 import json
 
+MAX_QUERY_LENGTH = 4096
 
 # ============================================================================
-def append_method_query(req, resp):
+def append_method_query_from_req_resp(req, resp):
     len_ = req.http_headers.get_header("Content-Length")
     content_type = req.http_headers.get_header("Content-Type")
     stream = req.buffered_stream
     stream.seek(0)
 
     url = req.rec_headers.get_header("WARC-Target-URI")
+    method = req.http_headers.protocol
+    return append_method_query(method, content_type, len_, stream, url)
 
-    query = query_extract(content_type, len_, stream, url)
+
+# ============================================================================
+def append_method_query(method, content_type, len_, stream, url):
+    #if method == 'GET':
+    #    return '', ''
+
+    if method == 'POST' or method == 'PUT':
+        query = query_extract(content_type, len_, stream, url)
+    else:
+        query = ''
 
     if "?" not in url:
         append_str = "?"
     else:
         append_str = "&"
 
-    method = req.http_headers.protocol
-    append_str += "__wb_method=" + method + "&" + query
+    append_str += "__wb_method=" + method
+    if query:
+        append_str += "&" + query
+
     return query, append_str
 
 
@@ -37,12 +53,15 @@ def query_extract(mime, length, stream, url):
     Attempt to decode application/x-www-form-urlencoded or multipart/*,
     otherwise read whole block and b64encode
     """
-    query = b""
+    query_data = b""
 
     try:
         length = int(length)
     except (ValueError, TypeError):
-        length = 8192
+        if length is None:
+            length = 8192
+        else:
+            return
 
     while length > 0:
         buff = stream.read(length)
@@ -52,69 +71,93 @@ def query_extract(mime, length, stream, url):
         if not buff:
             break
 
-        query += buff
+        query_data += buff
 
     if not mime:
         mime = ""
 
-    def handle_binary(query):
-        query = base64.b64encode(query)
+    query = ""
+
+    def handle_binary(query_data):
+        query = base64.b64encode(query_data)
         query = to_native_str(query)
         query = "__wb_post_data=" + query
         return query
 
     if mime.startswith("application/x-www-form-urlencoded"):
         try:
-            query = to_native_str(query.decode("utf-8"))
+            query = to_native_str(query_data.decode("utf-8"))
             query = unquote_plus(query)
         except UnicodeDecodeError:
-            query = handle_binary(query)
+            query = handle_binary(query_data)
 
     elif mime.startswith("multipart/"):
         env = {
             "REQUEST_METHOD": "POST",
             "CONTENT_TYPE": mime,
-            "CONTENT_LENGTH": len(query),
+            "CONTENT_LENGTH": len(query_data),
         }
 
-        args = dict(fp=BytesIO(query), environ=env, keep_blank_values=True)
+        args = dict(fp=BytesIO(query_data), environ=env, keep_blank_values=True)
 
         args["encoding"] = "utf-8"
 
-        data = cgi.FieldStorage(**args)
+        try:
+            data = cgi.FieldStorage(**args)
+        except ValueError:
+            # Content-Type multipart/form-data may lack "boundary" info
+            query = handle_binary(query_data)
+        else:
+            values = []
+            for item in data.list:
+                values.append((item.name, item.value))
 
-        values = []
-        for item in data.list:
-            values.append((item.name, item.value))
+            query = urlencode(values, True)
 
-        query = urlencode(values, True)
+    elif mime.startswith('application/json'):
+        try:
+            query = json_parse(query_data)
+        except Exception as e:
+            print(e)
+            query = ""
 
-    elif mime.startswith("application/json"):
-        query = json_parse(query.decode("utf-8"), True)
+    elif mime.startswith('text/plain'):
+        try:
+            query = json_parse(query_data)
+        except Exception as e:
+            query = handle_binary(query_data)
 
-    elif mime.startswith("text/plain"):
-        query = json_parse(query.decode("utf-8"), False)
-
+    elif mime.startswith('application/x-amf'):
+        query = amf_parse(query_data)
     else:
-        query = handle_binary(query)
+        query = handle_binary(query_data)
+
+    if query:
+        query = query[:MAX_QUERY_LENGTH]
 
     return query
 
 
-def json_parse(string, warn_on_error=False):
+def json_parse(string):
     data = {}
+    dupes = {}
+
+    def get_key(n):
+        if n not in data:
+            return n
+
+        if n not in dupes:
+            dupes[n] = 1
+
+        dupes[n] += 1
+        return n + "." + str(dupes[n]) + "_";
 
     def _parser(dict_var):
         for n, v in dict_var.items():
             if isinstance(v, dict):
                 _parser(v)
             else:
-                data[n] = v
+                data[get_key(n)] = str(v)
 
-    try:
-        _parser(json.loads(string))
-    except Exception as e:
-        if warn_on_error:
-            print(e)
-
+    _parser(json.loads(string))
     return urlencode(data)

--- a/cdxj_indexer/postquery.py
+++ b/cdxj_indexer/postquery.py
@@ -25,13 +25,13 @@ def append_method_query_from_req_resp(req, resp):
 
 # ============================================================================
 def append_method_query(method, content_type, len_, stream, url):
-    #if method == 'GET':
+    # if method == 'GET':
     #    return '', ''
 
-    if method == 'POST' or method == 'PUT':
+    if method == "POST" or method == "PUT":
         query = query_extract(content_type, len_, stream, url)
     else:
-        query = ''
+        query = ""
 
     if "?" not in url:
         append_str = "?"
@@ -114,20 +114,20 @@ def query_extract(mime, length, stream, url):
 
             query = urlencode(values, True)
 
-    elif mime.startswith('application/json'):
+    elif mime.startswith("application/json"):
         try:
             query = json_parse(query_data)
         except Exception as e:
             print(e)
             query = ""
 
-    elif mime.startswith('text/plain'):
+    elif mime.startswith("text/plain"):
         try:
             query = json_parse(query_data)
         except Exception as e:
             query = handle_binary(query_data)
 
-    elif mime.startswith('application/x-amf'):
+    elif mime.startswith("application/x-amf"):
         query = amf_parse(query_data)
     else:
         query = handle_binary(query_data)
@@ -150,7 +150,7 @@ def json_parse(string):
             dupes[n] = 1
 
         dupes[n] += 1
-        return n + "." + str(dupes[n]) + "_";
+        return n + "." + str(dupes[n]) + "_"
 
     def _parser(dict_var):
         for n, v in dict_var.items():

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 
 class PyTest(TestCommand):
@@ -50,6 +50,7 @@ setup(
         "surt",
         # temp fix for requests
         "idna<3.0",
+        "py3amf",
     ],
     zip_safe=True,
     entry_points="""

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -229,16 +229,23 @@ org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 790,
                 digest_records=True,
             )
 
-        exp = """\
-!meta 0 {"format": "cdxj-gzip-1.0", "filename": "%s"}
-com,example)/ 20140102000000 {"offset": 0, "length": 1292, "digest": "sha256:292fe51e52dabf0ceb7a00b878413e5e7820ce3d6aa9de7699cbaffe12723049"}
-org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 1292, "length": 428, "digest": "sha256:a5aa0ce18f4e147c4ae72c27d6603a14652a621488305dbf6482427de0f19138"}
-"""
-        assert res == exp % "comp_2.cdxj.gz"
+        lines = res.strip().split("\n")
+
+        assert len(lines) == 3
+        assert (
+            lines[0]
+            == '!meta 0 {"format": "cdxj-gzip-1.0", "filename": "comp_2.cdxj.gz"}'
+        )
+        assert lines[1].startswith(
+            'com,example)/ 20140102000000 {"offset": 0, "length": 1292, "digest": "sha256:'
+        )
+        assert lines[2].startswith(
+            'org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 1292, "length": 428, "digest": "sha256:'
+        )
 
         # specify named temp file, extension auto-added
         with tempfile.NamedTemporaryFile() as temp_fh:
-            res = self.index_file(
+            res2 = self.index_file(
                 "",
                 sort=True,
                 post_append=True,
@@ -248,11 +255,11 @@ org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 1292
             )
             name = temp_fh.name
 
-        assert res == exp % (name + ".cdxj.gz")
+        assert res2 == res.replace("comp_2", name)
 
         # specify named temp file, with extension suffix
         with tempfile.NamedTemporaryFile(suffix=".cdxj.gz") as temp2_fh:
-            res = self.index_file(
+            res3 = self.index_file(
                 "",
                 sort=True,
                 post_append=True,
@@ -262,7 +269,7 @@ org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 1292
             )
             name = temp2_fh.name
 
-        assert res == exp % name
+        assert res3 == res.replace("comp_2.cdxj.gz", name)
 
     def test_warc_index_add_custom_fields(self):
         res = self.index_file("example.warc.gz", fields="method,referrer,http:date")

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -226,7 +226,7 @@ org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 790,
                 compress=temp_fh,
                 data_out_name="comp_2.cdxj.gz",
                 lines=11,
-                digest_records=True
+                digest_records=True,
             )
 
         exp = """\
@@ -239,7 +239,12 @@ org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 1292
         # specify named temp file, extension auto-added
         with tempfile.NamedTemporaryFile() as temp_fh:
             res = self.index_file(
-                "", sort=True, post_append=True, compress=temp_fh.name, lines=11, digest_records=True
+                "",
+                sort=True,
+                post_append=True,
+                compress=temp_fh.name,
+                lines=11,
+                digest_records=True,
             )
             name = temp_fh.name
 
@@ -248,13 +253,16 @@ org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 1292
         # specify named temp file, with extension suffix
         with tempfile.NamedTemporaryFile(suffix=".cdxj.gz") as temp2_fh:
             res = self.index_file(
-                "", sort=True, post_append=True, compress=temp2_fh.name, lines=11, digest_records=True
+                "",
+                sort=True,
+                post_append=True,
+                compress=temp2_fh.name,
+                lines=11,
+                digest_records=True,
             )
             name = temp2_fh.name
 
         assert res == exp % name
-
-
 
     def test_warc_index_add_custom_fields(self):
         res = self.index_file("example.warc.gz", fields="method,referrer,http:date")

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -29,39 +29,59 @@ class TestIndexing(object):
         write_cdx_index(output, paths, opts)
         return output.getvalue()
 
-    def index_file_cli(self, filename, capsys):
-        res = main([os.path.join(TEST_DIR, filename)])
+    def index_file_cli(self, filename, capsys, extra_params=None):
+        params = [os.path.join(TEST_DIR, filename)]
+        if extra_params:
+            params += extra_params
+
+        res = main(params)
 
         return capsys.readouterr().out
 
     def test_warc_cdxj(self):
         res = self.index_file("example.warc.gz")
         exp = """\
-com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz"}
-com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz"}
+com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz"}
 """
         assert res == exp
 
     def test_warc_cdxj_cli_main(self, capsys):
         res = self.index_file_cli("example.warc.gz", capsys)
         exp = """\
-com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz"}
-com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz"}
+com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz"}
+"""
+        assert res == exp
+
+    def test_warc_cdxj_with_record_digests(self):
+        res = self.index_file("example.warc.gz", digest_records=True, post_append=True)
+        exp = """\
+com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz", "recordDigest": "sha256:1ebd93871e6de75fb72d5398452e4152cf3d655ae31368e7336c1b57870d244c"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz", "recordDigest": "sha256:f67dfffc2d78d025030574b08ad57211d2d2211ae49d566adf7868072a823f74"}
+"""
+        assert res == exp
+
+    def test_warc_cdxj_cli_main_with_record_digests(self, capsys):
+        res = self.index_file_cli("example.warc.gz", capsys, ["-d", "-p"])
+        exp = """\
+com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz", "recordDigest": "sha256:1ebd93871e6de75fb72d5398452e4152cf3d655ae31368e7336c1b57870d244c"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz", "recordDigest": "sha256:f67dfffc2d78d025030574b08ad57211d2d2211ae49d566adf7868072a823f74"}
 """
         assert res == exp
 
     def test_warc_cdxj_sorted(self):
         res = self.index_file("cc.warc.gz", sort=True)
         exp = """\
-org,commoncrawl)/ 20170722005011 {"url": "https://commoncrawl.org/", "mime": "text/html", "status": "200", "digest": "RXZILWL37W7MAZTH76FEVIHSF2DZ5HTM", "length": "5357", "offset": "377", "filename": "cc.warc.gz"}
+org,commoncrawl)/ 20170722005011 {"url": "https://commoncrawl.org/", "mime": "text/html", "status": "200", "digest": "sha1:RXZILWL37W7MAZTH76FEVIHSF2DZ5HTM", "length": "5357", "offset": "377", "filename": "cc.warc.gz"}
 """
         assert res == exp
 
     def test_warc_cdxj_dir_root(self):
         res = self.index_file("example.warc.gz", dir_root="./")
         exp = """\
-com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "test/data/example.warc.gz"}
-com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "test/data/example.warc.gz"}
+com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "test/data/example.warc.gz"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "test/data/example.warc.gz"}
 """
         assert res == exp
 
@@ -96,8 +116,8 @@ com,example)/ 20170306040348 http://example.com/ warc/revisit 200 G7HRM7BGOKSKMS
     def test_warc_request_only(self):
         res = self.index_file("example.warc.gz", records="request", fields="method")
         exp = """\
-com,example)/ 20170306040206 {"url": "http://example.com/", "digest": "3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ", "length": "609", "offset": "2026", "filename": "example.warc.gz", "method": "GET"}
-com,example)/ 20170306040348 {"url": "http://example.com/", "digest": "3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ", "length": "609", "offset": "3220", "filename": "example.warc.gz", "method": "GET"}
+com,example)/ 20170306040206 {"url": "http://example.com/", "digest": "sha1:3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ", "length": "609", "offset": "2026", "filename": "example.warc.gz", "method": "GET"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "digest": "sha1:3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ", "length": "609", "offset": "3220", "filename": "example.warc.gz", "method": "GET"}
 """
         assert res == exp
 
@@ -106,10 +126,10 @@ com,example)/ 20170306040348 {"url": "http://example.com/", "digest": "3I42H3S6N
         exp = """\
 - 20170306040353 {"mime": "application/warc-fields", "length": "353", "offset": "0", "filename": "example.warc.gz"}
 - 20170306040353 {"mime": "application/warc-fields", "length": "431", "offset": "353", "filename": "example.warc.gz"}
-com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz"}
-com,example)/ 20170306040206 {"url": "http://example.com/", "digest": "3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ", "length": "609", "offset": "2026", "filename": "example.warc.gz"}
-com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz"}
-com,example)/ 20170306040348 {"url": "http://example.com/", "digest": "3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ", "length": "609", "offset": "3220", "filename": "example.warc.gz"}
+com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz"}
+com,example)/ 20170306040206 {"url": "http://example.com/", "digest": "sha1:3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ", "length": "609", "offset": "2026", "filename": "example.warc.gz"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "digest": "sha1:3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ", "length": "609", "offset": "3220", "filename": "example.warc.gz"}
 """
         assert res == exp
 
@@ -119,7 +139,7 @@ com,example)/ 20170306040348 {"url": "http://example.com/", "digest": "3I42H3S6N
     def test_arc_cdxj(self):
         res = self.index_file("example.arc")
         exp = """\
-com,example)/ 20140216050221 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "B2LTWWPUOYAH7UIPQ7ZUPQ4VMBSVC36A", "length": "1656", "offset": "151", "filename": "example.arc"}
+com,example)/ 20140216050221 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "sha1:B2LTWWPUOYAH7UIPQ7ZUPQ4VMBSVC36A", "length": "1656", "offset": "151", "filename": "example.arc"}
 """
         assert res == exp
 
@@ -136,26 +156,26 @@ com,example)/ 20140401000000 http://example.com/ - - 3I42H3S6NNFQ2MSVX7XZKYAYSCX
     def test_warc_post_query_append(self):
         res = self.index_file("post-test.warc.gz", post_append=True)
         exp = """\
-org,httpbin)/post?__wb_method=post&foo=bar&test=abc 20140610000859 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M532K5WS4GY2H4OVZO6HRPOP47A7KDWU", "length": "720", "offset": "0", "filename": "post-test.warc.gz", "requestBody": "foo=bar&test=abc", "method": "POST"}
-org,httpbin)/post?__wb_method=post&a=1&b=[]&c=3 20140610001151 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2", "length": "723", "offset": "1196", "filename": "post-test.warc.gz", "requestBody": "A=1&B=[]&C=3", "method": "POST"}
-org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=bar", "mime": "application/json", "status": "200", "digest": "B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ", "length": "723", "offset": "2395", "filename": "post-test.warc.gz", "requestBody": "data=^", "method": "POST"}
+org,httpbin)/post?__wb_method=post&foo=bar&test=abc 20140610000859 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "sha1:M532K5WS4GY2H4OVZO6HRPOP47A7KDWU", "length": "720", "offset": "0", "filename": "post-test.warc.gz", "requestBody": "foo=bar&test=abc", "method": "POST"}
+org,httpbin)/post?__wb_method=post&a=1&b=[]&c=3 20140610001151 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "sha1:M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2", "length": "723", "offset": "1196", "filename": "post-test.warc.gz", "requestBody": "A=1&B=[]&C=3", "method": "POST"}
+org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=bar", "mime": "application/json", "status": "200", "digest": "sha1:B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ", "length": "723", "offset": "2395", "filename": "post-test.warc.gz", "requestBody": "data=^", "method": "POST"}
 """
         assert res == exp
 
         res = self.index_file("post-test.warc.gz")
         exp = """\
-org,httpbin)/post 20140610000859 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M532K5WS4GY2H4OVZO6HRPOP47A7KDWU", "length": "720", "offset": "0", "filename": "post-test.warc.gz"}
-org,httpbin)/post 20140610001151 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2", "length": "723", "offset": "1196", "filename": "post-test.warc.gz"}
-org,httpbin)/post?foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=bar", "mime": "application/json", "status": "200", "digest": "B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ", "length": "723", "offset": "2395", "filename": "post-test.warc.gz"}
+org,httpbin)/post 20140610000859 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "sha1:M532K5WS4GY2H4OVZO6HRPOP47A7KDWU", "length": "720", "offset": "0", "filename": "post-test.warc.gz"}
+org,httpbin)/post 20140610001151 {"url": "http://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "sha1:M7YCTM7HS3YKYQTAWQVMQSQZBNEOXGU2", "length": "723", "offset": "1196", "filename": "post-test.warc.gz"}
+org,httpbin)/post?foo=bar 20140610001255 {"url": "http://httpbin.org/post?foo=bar", "mime": "application/json", "status": "200", "digest": "sha1:B6E5P6JUZI6UPDTNO4L2BCHMGLTNCUAJ", "length": "723", "offset": "2395", "filename": "post-test.warc.gz"}
 """
         assert res == exp
 
     def test_warc_post_query_append_multi_and_json(self):
         res = self.index_file("post-test-more.warc", post_append=True)
         exp = """\
-org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "7AWVEIPQMCA4KTCNDXWSZ465FITB7LSK", "length": "688", "offset": "0", "filename": "post-test-more.warc", "requestBody": "test=some+data&another=more%5Edata", "method": "POST"}
-org,httpbin)/post?__wb_method=post&a=json-data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "BYOQWRSQFW3A5SNUBDSASHFLXGL4FNGB", "length": "655", "offset": "1227", "filename": "post-test-more.warc", "requestBody": "a=json-data", "method": "POST"}
-org,httpbin)/post?__wb_method=post&__wb_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 20200810055049 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "34LEADQD3MOBQ42FCO2WA5TUSEL5QOKP", "length": "628", "offset": "2338", "filename": "post-test-more.warc", "requestBody": "__wb_post_data=c29tZWNodW5rLWVuY29kZWRkYXRh", "method": "POST"}
+org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "sha1:7AWVEIPQMCA4KTCNDXWSZ465FITB7LSK", "length": "688", "offset": "0", "filename": "post-test-more.warc", "requestBody": "test=some+data&another=more%5Edata", "method": "POST"}
+org,httpbin)/post?__wb_method=post&a=json-data 20200809195334 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "sha1:BYOQWRSQFW3A5SNUBDSASHFLXGL4FNGB", "length": "655", "offset": "1227", "filename": "post-test-more.warc", "requestBody": "a=json-data", "method": "POST"}
+org,httpbin)/post?__wb_method=post&__wb_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 20200810055049 {"url": "https://httpbin.org/post", "mime": "application/json", "status": "200", "digest": "sha1:34LEADQD3MOBQ42FCO2WA5TUSEL5QOKP", "length": "628", "offset": "2338", "filename": "post-test-more.warc", "requestBody": "__wb_post_data=c29tZWNodW5rLWVuY29kZWRkYXRh", "method": "POST"}
 """
         assert res == exp
 
@@ -173,8 +193,8 @@ org,httpbin)/post?__wb_method=post&__wb_post_data=c29tzwnodw5rlwvuy29kzwrkyxrh 2
 
         exp = """\
 !meta 0 {"format": "cdxj-gzip-1.0", "filename": "%s"}
-com,example)/ 20140102000000 {"offset": 0, "length": 784}
-org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 784, "length": 321}
+com,example)/ 20140102000000 {"offset": 0, "length": 790}
+org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 790, "length": 325}
 """
         assert res == exp % "comp.cdxj.gz"
 
@@ -196,12 +216,52 @@ org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 784,
 
         assert res == exp % name
 
+    def test_warc_cdxj_compressed_2_with_digest(self):
+        # specify file directly
+        with tempfile.TemporaryFile() as temp_fh:
+            res = self.index_file(
+                "",
+                sort=True,
+                post_append=True,
+                compress=temp_fh,
+                data_out_name="comp_2.cdxj.gz",
+                lines=11,
+                digest_records=True
+            )
+
+        exp = """\
+!meta 0 {"format": "cdxj-gzip-1.0", "filename": "%s"}
+com,example)/ 20140102000000 {"offset": 0, "length": 1292, "digest": "sha256:292fe51e52dabf0ceb7a00b878413e5e7820ce3d6aa9de7699cbaffe12723049"}
+org,httpbin)/post?__wb_method=post&data=^&foo=bar 20140610001255 {"offset": 1292, "length": 428, "digest": "sha256:a5aa0ce18f4e147c4ae72c27d6603a14652a621488305dbf6482427de0f19138"}
+"""
+        assert res == exp % "comp_2.cdxj.gz"
+
+        # specify named temp file, extension auto-added
+        with tempfile.NamedTemporaryFile() as temp_fh:
+            res = self.index_file(
+                "", sort=True, post_append=True, compress=temp_fh.name, lines=11, digest_records=True
+            )
+            name = temp_fh.name
+
+        assert res == exp % (name + ".cdxj.gz")
+
+        # specify named temp file, with extension suffix
+        with tempfile.NamedTemporaryFile(suffix=".cdxj.gz") as temp2_fh:
+            res = self.index_file(
+                "", sort=True, post_append=True, compress=temp2_fh.name, lines=11, digest_records=True
+            )
+            name = temp2_fh.name
+
+        assert res == exp % name
+
+
+
     def test_warc_index_add_custom_fields(self):
         res = self.index_file("example.warc.gz", fields="method,referrer,http:date")
 
         exp = """\
-com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz", "method": "GET", "referrer": "https://webrecorder.io/temp-MJFXHZ4S/temp/recording-session/record/http://example.com/", "http:date": "Mon, 06 Mar 2017 04:02:06 GMT"}
-com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz", "http:date": "Mon, 06 Mar 2017 04:03:48 GMT"}
+com,example)/ 20170306040206 {"url": "http://example.com/", "mime": "text/html", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "1242", "offset": "784", "filename": "example.warc.gz", "method": "GET", "referrer": "https://webrecorder.io/temp-MJFXHZ4S/temp/recording-session/record/http://example.com/", "http:date": "Mon, 06 Mar 2017 04:02:06 GMT"}
+com,example)/ 20170306040348 {"url": "http://example.com/", "mime": "warc/revisit", "status": "200", "digest": "sha1:G7HRM7BGOKSKMSXZAHMUQTTV53QOFSMK", "length": "585", "offset": "2635", "filename": "example.warc.gz", "http:date": "Mon, 06 Mar 2017 04:03:48 GMT"}
 """
         assert res == exp
 

--- a/test/test_postappend.py
+++ b/test/test_postappend.py
@@ -8,7 +8,7 @@ from cdxj_indexer.amf import amf_parse
 
 
 # ============================================================================
-class MethodQueryCanonicalizer():
+class MethodQueryCanonicalizer:
     def __init__(self, method, content_type, req_len, req_stream):
         self.method = method
         self.content_type = content_type
@@ -17,7 +17,9 @@ class MethodQueryCanonicalizer():
 
     def append_query(self, url):
         self.req_stream.seek(0)
-        query_only, full_string = append_method_query(self.method, self.content_type, self.req_len, self.req_stream, url)
+        query_only, full_string = append_method_query(
+            self.method, self.content_type, self.req_len, self.req_stream, url
+        )
         return url + full_string
 
 
@@ -25,101 +27,170 @@ class MethodQueryCanonicalizer():
 class TestPostQueryExtract(object):
     @classmethod
     def setup_class(cls):
-        cls.post_data = b'foo=bar&dir=%2Fbaz'
-        cls.binary_post_data = b'\x816l`L\xa04P\x0e\xe0r\x02\xb5\x89\x19\x00fP\xdb\x0e\xb0\x02,'
+        cls.post_data = b"foo=bar&dir=%2Fbaz"
+        cls.binary_post_data = (
+            b"\x816l`L\xa04P\x0e\xe0r\x02\xb5\x89\x19\x00fP\xdb\x0e\xb0\x02,"
+        )
 
     def test_post_extract_1(self):
-        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
-                                len(self.post_data), BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST",
+            "application/x-www-form-urlencoded",
+            len(self.post_data),
+            BytesIO(self.post_data),
+        )
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&foo=bar&dir=/baz'
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&foo=bar&dir=/baz"
+        )
 
-        assert mq.append_query('http://example.com/?123=ABC') == 'http://example.com/?123=ABC&__wb_method=POST&foo=bar&dir=/baz'
+        assert (
+            mq.append_query("http://example.com/?123=ABC")
+            == "http://example.com/?123=ABC&__wb_method=POST&foo=bar&dir=/baz"
+        )
 
     def test_post_extract_json(self):
         post_data = b'{"a": "b", "c": {"a": 2}, "d": "e"}'
-        mq = MethodQueryCanonicalizer('POST', 'application/json',
-                                len(post_data), BytesIO(post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST", "application/json", len(post_data), BytesIO(post_data)
+        )
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&a=b&a.2_=2&d=e'
-
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&a=b&a.2_=2&d=e"
+        )
 
     def test_put_extract_method(self):
-        mq = MethodQueryCanonicalizer('PUT', 'application/x-www-form-urlencoded',
-                                len(self.post_data), BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "PUT",
+            "application/x-www-form-urlencoded",
+            len(self.post_data),
+            BytesIO(self.post_data),
+        )
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=PUT&foo=bar&dir=/baz'
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=PUT&foo=bar&dir=/baz"
+        )
 
     def test_post_extract_non_form_data_1(self):
-        mq = MethodQueryCanonicalizer('POST', 'application/octet-stream',
-                                len(self.post_data), BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST",
+            "application/octet-stream",
+            len(self.post_data),
+            BytesIO(self.post_data),
+        )
 
-        #base64 encoded data
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6'
+        # base64 encoded data
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6"
+        )
 
     def test_post_extract_non_form_data_2(self):
-        mq = MethodQueryCanonicalizer('POST', 'text/plain',
-                                len(self.post_data), BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST", "text/plain", len(self.post_data), BytesIO(self.post_data)
+        )
 
-        #base64 encoded data
-        assert mq.append_query('http://example.com/pathbar?id=123') == 'http://example.com/pathbar?id=123&__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6'
+        # base64 encoded data
+        assert (
+            mq.append_query("http://example.com/pathbar?id=123")
+            == "http://example.com/pathbar?id=123&__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6"
+        )
 
     def test_post_extract_length_invalid_ignore(self):
-        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
-                                0, BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST", "application/x-www-form-urlencoded", 0, BytesIO(self.post_data)
+        )
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST'
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST"
+        )
 
-        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
-                                'abc', BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST", "application/x-www-form-urlencoded", "abc", BytesIO(self.post_data)
+        )
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST'
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST"
+        )
 
     def test_post_extract_length_too_short(self):
-        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
-                                len(self.post_data) - 4, BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST",
+            "application/x-www-form-urlencoded",
+            len(self.post_data) - 4,
+            BytesIO(self.post_data),
+        )
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&foo=bar&dir=%2'
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&foo=bar&dir=%2"
+        )
 
     def test_post_extract_length_too_long(self):
-        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
-                                len(self.post_data) + 4, BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST",
+            "application/x-www-form-urlencoded",
+            len(self.post_data) + 4,
+            BytesIO(self.post_data),
+        )
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&foo=bar&dir=/baz'
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&foo=bar&dir=/baz"
+        )
 
     def test_post_extract_malformed_form_data(self):
-        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
-                                len(self.binary_post_data), BytesIO(self.binary_post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST",
+            "application/x-www-form-urlencoded",
+            len(self.binary_post_data),
+            BytesIO(self.binary_post_data),
+        )
 
-        #base64 encoded data
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&__wb_post_data=gTZsYEygNFAO4HICtYkZAGZQ2w6wAiw='
+        # base64 encoded data
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&__wb_post_data=gTZsYEygNFAO4HICtYkZAGZQ2w6wAiw="
+        )
 
     def test_post_extract_no_boundary_in_multipart_form_mimetype(self):
-        mq = MethodQueryCanonicalizer('POST', 'multipart/form-data',
-                                len(self.post_data), BytesIO(self.post_data))
+        mq = MethodQueryCanonicalizer(
+            "POST", "multipart/form-data", len(self.post_data), BytesIO(self.post_data)
+        )
 
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6'
-
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6"
+        )
 
     def test_options(self):
-        mq = MethodQueryCanonicalizer('OPTIONS', '', 0, BytesIO())
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=OPTIONS'
+        mq = MethodQueryCanonicalizer("OPTIONS", "", 0, BytesIO())
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=OPTIONS"
+        )
 
     def test_head(self):
-        mq = MethodQueryCanonicalizer('HEAD', '', 0, BytesIO())
-        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=HEAD'
+        mq = MethodQueryCanonicalizer("HEAD", "", 0, BytesIO())
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=HEAD"
+        )
 
     def test_amf_parse(self):
-        mq = MethodQueryCanonicalizer('POST', 'application/x-amf', 0, BytesIO())
+        mq = MethodQueryCanonicalizer("POST", "application/x-amf", 0, BytesIO())
 
-        req = Request(target='t', body="")
+        req = Request(target="t", body="")
         ev_1 = Envelope(AMF3)
-        ev_1['/0'] = req
+        ev_1["/0"] = req
 
-        req = Request(target='t', body="alt_content")
+        req = Request(target="t", body="alt_content")
         ev_2 = Envelope(AMF3)
-        ev_2['/0'] = req
+        ev_2["/0"] = req
 
-        assert amf_parse(encode(ev_1).getvalue()) != \
-               amf_parse(encode(ev_2).getvalue())
-
+        assert amf_parse(encode(ev_1).getvalue()) != amf_parse(encode(ev_2).getvalue())

--- a/test/test_postappend.py
+++ b/test/test_postappend.py
@@ -1,0 +1,125 @@
+from io import BytesIO
+
+from pyamf import AMF3
+from pyamf.remoting import Request, Envelope, encode
+
+from cdxj_indexer.postquery import append_method_query
+from cdxj_indexer.amf import amf_parse
+
+
+# ============================================================================
+class MethodQueryCanonicalizer():
+    def __init__(self, method, content_type, req_len, req_stream):
+        self.method = method
+        self.content_type = content_type
+        self.req_len = req_len
+        self.req_stream = req_stream
+
+    def append_query(self, url):
+        self.req_stream.seek(0)
+        query_only, full_string = append_method_query(self.method, self.content_type, self.req_len, self.req_stream, url)
+        return url + full_string
+
+
+# ============================================================================
+class TestPostQueryExtract(object):
+    @classmethod
+    def setup_class(cls):
+        cls.post_data = b'foo=bar&dir=%2Fbaz'
+        cls.binary_post_data = b'\x816l`L\xa04P\x0e\xe0r\x02\xb5\x89\x19\x00fP\xdb\x0e\xb0\x02,'
+
+    def test_post_extract_1(self):
+        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
+                                len(self.post_data), BytesIO(self.post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&foo=bar&dir=/baz'
+
+        assert mq.append_query('http://example.com/?123=ABC') == 'http://example.com/?123=ABC&__wb_method=POST&foo=bar&dir=/baz'
+
+    def test_post_extract_json(self):
+        post_data = b'{"a": "b", "c": {"a": 2}, "d": "e"}'
+        mq = MethodQueryCanonicalizer('POST', 'application/json',
+                                len(post_data), BytesIO(post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&a=b&a.2_=2&d=e'
+
+
+    def test_put_extract_method(self):
+        mq = MethodQueryCanonicalizer('PUT', 'application/x-www-form-urlencoded',
+                                len(self.post_data), BytesIO(self.post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=PUT&foo=bar&dir=/baz'
+
+    def test_post_extract_non_form_data_1(self):
+        mq = MethodQueryCanonicalizer('POST', 'application/octet-stream',
+                                len(self.post_data), BytesIO(self.post_data))
+
+        #base64 encoded data
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6'
+
+    def test_post_extract_non_form_data_2(self):
+        mq = MethodQueryCanonicalizer('POST', 'text/plain',
+                                len(self.post_data), BytesIO(self.post_data))
+
+        #base64 encoded data
+        assert mq.append_query('http://example.com/pathbar?id=123') == 'http://example.com/pathbar?id=123&__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6'
+
+    def test_post_extract_length_invalid_ignore(self):
+        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
+                                0, BytesIO(self.post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST'
+
+        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
+                                'abc', BytesIO(self.post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST'
+
+    def test_post_extract_length_too_short(self):
+        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
+                                len(self.post_data) - 4, BytesIO(self.post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&foo=bar&dir=%2'
+
+    def test_post_extract_length_too_long(self):
+        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
+                                len(self.post_data) + 4, BytesIO(self.post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&foo=bar&dir=/baz'
+
+    def test_post_extract_malformed_form_data(self):
+        mq = MethodQueryCanonicalizer('POST', 'application/x-www-form-urlencoded',
+                                len(self.binary_post_data), BytesIO(self.binary_post_data))
+
+        #base64 encoded data
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&__wb_post_data=gTZsYEygNFAO4HICtYkZAGZQ2w6wAiw='
+
+    def test_post_extract_no_boundary_in_multipart_form_mimetype(self):
+        mq = MethodQueryCanonicalizer('POST', 'multipart/form-data',
+                                len(self.post_data), BytesIO(self.post_data))
+
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=POST&__wb_post_data=Zm9vPWJhciZkaXI9JTJGYmF6'
+
+
+    def test_options(self):
+        mq = MethodQueryCanonicalizer('OPTIONS', '', 0, BytesIO())
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=OPTIONS'
+
+    def test_head(self):
+        mq = MethodQueryCanonicalizer('HEAD', '', 0, BytesIO())
+        assert mq.append_query('http://example.com/') == 'http://example.com/?__wb_method=HEAD'
+
+    def test_amf_parse(self):
+        mq = MethodQueryCanonicalizer('POST', 'application/x-amf', 0, BytesIO())
+
+        req = Request(target='t', body="")
+        ev_1 = Envelope(AMF3)
+        ev_1['/0'] = req
+
+        req = Request(target='t', body="alt_content")
+        ev_2 = Envelope(AMF3)
+        ev_2['/0'] = req
+
+        assert amf_parse(encode(ev_1).getvalue()) != \
+               amf_parse(encode(ev_2).getvalue())
+


### PR DESCRIPTION
- Support generating `recordDigest` for digest of entire WARC record, and `digest` of each CDX compressed cdx block.
- Port over POST append query functionality from pywb, to ensure complete compatibility between indexing from pywb and this implementation (includes support for duplicate JSON params, and AMF post content indexing).