### PR TITLE
collection records + sort optimizations

### DIFF
--- a/cdxj_indexer/bufferiter.py
+++ b/cdxj_indexer/bufferiter.py
@@ -91,7 +91,7 @@ def concur_req_resp(rec_1, rec_2):
 
 # ============================================================================
 def buffer_record_content(record):
-    spool = tempfile.SpooledTemporaryFile()
+    spool = tempfile.SpooledTemporaryFile(BUFF_SIZE)
     shutil.copyfileobj(record.content_stream(), spool)
     spool.seek(0)
     record.buffered_stream = spool

--- a/cdxj_indexer/main.py
+++ b/cdxj_indexer/main.py
@@ -394,7 +394,7 @@ class SortingWriter:
             self.sortedlist = []
             self.count = 0
 
-        open_files = [open(name, "rt") for name in self.tmp_files]
+        open_files = [open(name, "rt", encoding="utf-8") for name in self.tmp_files]
 
         self.write_to_file(heapq.merge(*open_files), self.out)
 

--- a/test/test_indexer.py
+++ b/test/test_indexer.py
@@ -226,6 +226,7 @@ org,httpbin)/post?__wb_method=post&another=more^data&test=some+data 202008091953
                 compress=temp_fh,
                 data_out_name="comp_2.cdxj.gz",
                 lines=11,
+                max_sort_buff_size=1000,
                 digest_records=True,
             )
 


### PR DESCRIPTION
- Fix a bug where SpooledTemporaryFile() did not have a max buffer size, resulting in reading everything into memory!
- Also add max size (currently 32MB) for amount of CDXJ lines to hold in memory. If size is exceeded, write to temp files and use `heapq.merge` to merge temp files into final output.