### PR TITLE
Replace deprecated cgi module with multipart for parsing multipart POST requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: checkout
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U black pytest pytest-cov
+          pip install -U black pytest pytest-cov setuptools[core]
           python setup.py -q install
 
       - name: Style Check

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         # temp fix for requests
         "idna<3.0",
         "py3amf",
+        "multipart",
     ],
     zip_safe=True,
     entry_points="""


### PR DESCRIPTION
Fixes #23 

Also updates CI to use Python 3.9-3.12 and to install setuptools from third party package.