### PR TITLE
Catch UTF8 parse errors

### DIFF
--- a/cdxj_indexer/postquery.py
+++ b/cdxj_indexer/postquery.py
@@ -104,7 +104,11 @@ def query_extract(mime, length, stream, url):
         else:
             values = []
             for part in parser:
-                values.append((part.name, part.value))
+                # if the value fails to decode as utf-8 base64 encode it
+                try:
+                    values.append((part.name, part.value))
+                except UnicodeDecodeError:
+                    values.append((part.name, handle_binary(part.raw)))
 
             query = urlencode(values, True)
 

--- a/cdxj_indexer/postquery.py
+++ b/cdxj_indexer/postquery.py
@@ -103,7 +103,11 @@ def query_extract(mime, length, stream, url):
         else:
             values = []
             for part in parser:
-                values.append((part.name, part.value))
+                # if the value fails to decode as utf-8 base64 encode it
+                try:
+                    values.append((part.name, part.value))
+                except UnicodeDecodeError:
+                    values.append((part.name, handle_binary(part.raw)))
 
             query = urlencode(values, True)
 

--- a/cdxj_indexer/postquery.py
+++ b/cdxj_indexer/postquery.py
@@ -103,7 +103,13 @@ def query_extract(mime, length, stream, url):
         else:
             values = []
             for part in parser:
-                # if the value fails to decode as utf-8 base64 encode it
+                # If the value fails to decode as utf-8 base64 encode it.
+                #
+                # See https://iipc.github.io/warc-specifications/guidelines/cdx-non-get-requests/
+                # 
+                # "The body must be decoded as form data per RFC 2388 and then percent plus encoded. 
+                # If the body is not a valid multipart/form-data message then the binary encoding 
+                # method must be used instead."
                 try:
                     values.append((part.name, part.value))
                 except UnicodeDecodeError:

--- a/cdxj_indexer/postquery.py
+++ b/cdxj_indexer/postquery.py
@@ -103,12 +103,39 @@ def query_extract(mime, length, stream, url):
         else:
             values = []
             for part in parser:
-                # If the value fails to decode as utf-8 base64 encode it.
+                # A part with a filename is a binary file upload, not a text
+                # field, so hand the raw bytes to urlencode to percent-encode.
+                # This is what the guideline below describes for a *valid*
+                # multipart body -- decode as form data per RFC 2388, then
+                # percent plus encode. The binary fallback further down only
+                # applies to bodies that aren't valid multipart at all, which
+                # a binary file part still is.
+                #
+                # It also matches cgi.FieldStorage, which this parser replaced
+                # and which pywb still uses at replay time: it returns bytes
+                # for file parts and never decodes them. Keeping the two in
+                # step is what makes a POST lookup hit.
+                #
+                # Do not "tidy" this into base64. surt unquotes the query and
+                # re-splits it on & and =, so raw bytes containing those get
+                # hoisted out into separate, alphabetically re-sorted query
+                # params -- the key for a binary body is genuinely garbled,
+                # and two bodies differing only in fragment order can collide.
+                # base64 survives canonicalization intact and looks far
+                # cleaner, but pywb never computes that key, so replay would
+                # silently stop matching. Fixing this properly needs a change
+                # to the guideline (and to pywb) on both sides at once.
+                if part.filename:
+                    values.append((part.name, part.raw))
+                    continue
+
+                # A non-file part that won't decode is malformed form data, so
+                # fall back to base64 for it.
                 #
                 # See https://iipc.github.io/warc-specifications/guidelines/cdx-non-get-requests/
-                # 
-                # "The body must be decoded as form data per RFC 2388 and then percent plus encoded. 
-                # If the body is not a valid multipart/form-data message then the binary encoding 
+                #
+                # "The body must be decoded as form data per RFC 2388 and then percent plus encoded.
+                # If the body is not a valid multipart/form-data message then the binary encoding
                 # method must be used instead."
                 try:
                     values.append((part.name, part.value))

--- a/test/test_postappend.py
+++ b/test/test_postappend.py
@@ -182,6 +182,23 @@ class TestPostQueryExtract(object):
             == "http://example.com/?__wb_method=POST&__wb_post_data=gTZsYEygNFAO4HICtYkZAGZQ2w6wAiw="
         )
 
+    def test_post_extract_binary_multipart_data(self):
+        # the message body contains a chr(0x9C) which isn't valid utf-8
+        body = b"""------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB\r\nContent-Disposition: form-data;name="ts"\r\n\r\n1761714108199\r\n------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB\r\nContent-Disposition: form-data; name="post_0"; filename="blob"\r\nContent-Type: application/octet-stream\r\n\r\n\x9c\r\n------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB--\r\n"""
+
+        mq = MethodQueryCanonicalizer(
+            "POST",
+            "multipart/form-data; boundary=----WebKitFormBoundaryXcDvJJ9bNZr1ZUTB",
+            len(body),
+            BytesIO(body),
+        )
+
+        # base64 encoded data
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&ts=1761714108199&post_0=__wb_post_data%3DnA%3D%3D"
+        )
+
     def test_post_extract_no_boundary_in_multipart_form_mimetype(self):
         mq = MethodQueryCanonicalizer(
             "POST", "multipart/form-data", len(self.post_data), BytesIO(self.post_data)

--- a/test/test_postappend.py
+++ b/test/test_postappend.py
@@ -183,7 +183,8 @@ class TestPostQueryExtract(object):
         )
 
     def test_post_extract_binary_multipart_data(self):
-        # the message body contains a chr(0x9C) which isn't valid utf-8
+        # a file part (it has a filename) whose body contains a chr(0x9C),
+        # which isn't valid utf-8 -- as sent by Facebook's /ajax/bz beacon
         body = b"""------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB\r\nContent-Disposition: form-data;name="ts"\r\n\r\n1761714108199\r\n------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB\r\nContent-Disposition: form-data; name="post_0"; filename="blob"\r\nContent-Type: application/octet-stream\r\n\r\n\x9c\r\n------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB--\r\n"""
 
         mq = MethodQueryCanonicalizer(
@@ -193,10 +194,28 @@ class TestPostQueryExtract(object):
             BytesIO(body),
         )
 
-        # base64 encoded data
+        # the raw bytes are percent-encoded, matching what cgi.FieldStorage
+        # (still used by pywb at replay time) produces for a file part
         assert (
             mq.append_query("http://example.com/")
-            == "http://example.com/?__wb_method=POST&ts=1761714108199&post_0=__wb_post_data%3DnA%3D%3D"
+            == "http://example.com/?__wb_method=POST&ts=1761714108199&post_0=%9C"
+        )
+
+    def test_post_extract_binary_multipart_non_file_part(self):
+        # same invalid utf-8 byte, but in a regular field rather than a file
+        # part, so the body is malformed form data and base64 is used instead
+        body = b"""------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB\r\nContent-Disposition: form-data; name="ts"\r\n\r\n1761714108199\r\n------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB\r\nContent-Disposition: form-data; name="field"\r\n\r\n\x9c\r\n------WebKitFormBoundaryXcDvJJ9bNZr1ZUTB--\r\n"""
+
+        mq = MethodQueryCanonicalizer(
+            "POST",
+            "multipart/form-data; boundary=----WebKitFormBoundaryXcDvJJ9bNZr1ZUTB",
+            len(body),
+            BytesIO(body),
+        )
+
+        assert (
+            mq.append_query("http://example.com/")
+            == "http://example.com/?__wb_method=POST&ts=1761714108199&field=__wb_post_data%3DnA%3D%3D"
         )
 
     def test_post_extract_no_boundary_in_multipart_form_mimetype(self):


### PR DESCRIPTION
If the part value doesn't decode as utf-8 convert it to base64 like other binary data.

I wonder if this is in keeping with the spirit of the [draft specification](https://iipc.github.io/warc-specifications/guidelines/cdx-non-get-requests/):

> The body must be decoded as form data per [RFC 2388](https://datatracker.ietf.org/doc/html/rfc2388) and then percent plus encoded. If the body is not a valid multipart/form-data message then the binary encoding method must be used instead.

Fixes #30
