### PR TITLE
ci: update python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: checkout


### PR DESCRIPTION
3.9 appears to have dropped off the list of supported pythons: https://github.com/webrecorder/cdxj-indexer/actions/runs/24482832380/job/71551090639#step:3:9

Updated to 3.10 through 3.14 instead.